### PR TITLE
Make links in notices bold

### DIFF
--- a/resources/styles/ext.networknotice.Notice.less
+++ b/resources/styles/ext.networknotice.Notice.less
@@ -33,6 +33,10 @@
 	&__content {
 		word-break: break-word;
 
+		a {
+			font-weight: bold;
+		}
+
 		&-wrapper {
 			border-right: 0.0625rem solid rgba( 0, 0, 0, 0.16 );
 			margin: 0.5rem 0;


### PR DESCRIPTION
According to the design the links in the network notices should appear in bold.