### PR TITLE
Network notices jump when loading the page

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -48,10 +48,13 @@
 		}
 	},
 	"ResourceModules": {
-		"ext.networknotice.Notice": {
+		"ext.networknotice.Notice.styles": {
 			"styles": [
 				"styles/ext.networknotice.Notice.less"
 			],
+			"position": "bottom"
+		},
+		"ext.networknotice.Notice.scripts": {
 			"scripts": [
 				"scripts/ext.networknotice.Notice.js"
 			],

--- a/src/Hooks/MainHookHandler.php
+++ b/src/Hooks/MainHookHandler.php
@@ -21,7 +21,8 @@ class MainHookHandler implements
 	 * @param Skin $skin
 	 */
 	public function onBeforePageDisplay( $out, $skin ): void {
-		$out->addModules( 'ext.networknotice.Notice' );
+		$out->addModuleStyles( 'ext.networknotice.Notice.styles' );
+		$out->addModules( 'ext.networknotice.Notice.scripts' );
 	}
 
 	/**


### PR DESCRIPTION
Currently on the live site the network notice styling is loading too late, which causes a jump when the page and the css loads. Based on Alex's feedback I separated the styles and scripts load in the ResourceModules.

I tested this on my wikidev and it seems to load a lot faster. 
http://laura.wiki.tldev.eu/rocketleague
