### PR TITLE
fix(script): only trigger event listener once

### DIFF
--- a/resources/scripts/ext.networknotice.Notice.js
+++ b/resources/scripts/ext.networknotice.Notice.js
@@ -54,6 +54,6 @@
 			if ( [ 'interactive', 'complete' ].includes( document.readyState ) ) {
 				init();
 			}
-		}, { once = true } );
+		}, { once: true } );
 	}
 }( window, document ) );

--- a/resources/scripts/ext.networknotice.Notice.js
+++ b/resources/scripts/ext.networknotice.Notice.js
@@ -54,6 +54,6 @@
 			if ( [ 'interactive', 'complete' ].includes( document.readyState ) ) {
 				init();
 			}
-		} );
+		}, { once = true } );
 	}
 }( window, document ) );


### PR DESCRIPTION
As mentioned by R1CH in https://github.com/Liquipedia/NetworkNotice/pull/10#issuecomment-2127334378, the event listener should only trigger once and then detach itself, otherwise `init()` can get triggered more than once.