### PR TITLE
Update left border color

### DIFF
--- a/resources/scripts/ext.networknotice.Notice.js
+++ b/resources/scripts/ext.networknotice.Notice.js
@@ -5,7 +5,7 @@
 
 	function init() {
 		if ( 'localStorage' in window ) {
-			document.querySelectorAll( '[data-component="network-notice"]' ).forEach( function( notice ) {
+			document.querySelectorAll( '[data-component="network-notice"]' ).forEach( ( notice ) => {
 				const key = notice.dataset.id;
 				if ( isInStorage( key ) ) {
 					notice.classList.add( 'd-none' );

--- a/resources/styles/ext.networknotice.Notice.less
+++ b/resources/styles/ext.networknotice.Notice.less
@@ -26,7 +26,7 @@
 		bottom: 0;
 		left: 0;
 		position: absolute;
-		background-color: var( --clr-wiki-primary );
+		background-color: var( --clr-wiki-theme-primary, var( --clr-wiki-primary ) );
 		border-radius: 0.5rem 0 0 0.5rem;
 	}
 


### PR DESCRIPTION
This MR updates the color variable for the border on the left side of the network notice, so it will match the design.
The reason is because the variable wasn't available yet at the time of updating the styling of the network notice. 

Also changed a function to an arrow function because the pipeline was failing

![image](https://github.com/Liquipedia/NetworkNotice/assets/105433238/03d8f77c-5fc8-4bd1-95f2-7f07e7d210e5)
![image](https://github.com/Liquipedia/NetworkNotice/assets/105433238/0ffd5b6f-f2a4-4308-ac3c-253475dea674)
